### PR TITLE
share: fix op pool

### DIFF
--- a/share/share.go
+++ b/share/share.go
@@ -68,6 +68,7 @@ func (e *sharePlugin) ListenOps(op interface{}) {
 		err = e.shareWebsite(*o)
 		tag = o.Tag
 	case *TextOp:
+		defer textOpPool.Release(o)
 		err = e.shareText(*o)
 		tag = o.Tag
 	}


### PR DESCRIPTION
Previously, the TextOp was never released, causing the OpPool to be inefficient.

Signed-off-by: inkeliz <inkeliz@inkeliz.com>